### PR TITLE
Update wiredep-copy.js

### DIFF
--- a/tasks/wiredep-copy.js
+++ b/tasks/wiredep-copy.js
@@ -21,6 +21,10 @@ module.exports = function(grunt) {
     });
 
     var dependencies = wiredepCopy.collate(options.wiredep);
+    // maybe more of the pre-checks: file exists but not a directory, ...
+    if (options.dest != '.' && !grunt.file.isDir(options.dest)) {
+      grunt.file.mkdir(options.dest);
+    }
     dependencies.forEach(function(dependency) {
       var dest = wiredepCopy.rename(dependency, options);
       grunt.file.copy(dependency, dest);


### PR DESCRIPTION
While transferring files from bower_components to dist:

```
Running "wiredepCopy:target" (wiredepCopy) task
Warning: ENOENT: no such file or directory, lstat 'D:\o\dist\bower_components' Use --force to continue.

Aborted due to warnings.
```

After the change:

```
Running "wiredepCopy:target" (wiredepCopy) task
D:\o\bower_components\jquery\jquery.js -> D:\o\dist\bower_components\jquery\jquery.js
[...]
```
